### PR TITLE
feat!: drop prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ go get go-simpler.org/env
 * Simple API
 * Dependency-free
 * Per-variable options: [required](#required), [expand](#expand)
-* Global options: [source](#source), [prefix](#prefix), [slice separator](#slice-separator)
+* Global options: [source](#source), [slice separator](#slice-separator)
 * Auto-generated [usage message](#usage-message)
 
 ## 📋 Usage
@@ -178,25 +178,6 @@ var cfg struct {
     Port int `env:"PORT"`
 }
 if err := env.Load(&cfg, env.WithSource(m)); err != nil {
-    fmt.Println(err)
-}
-
-fmt.Println(cfg.Port)
-// Output: 8080
-```
-
-#### Prefix
-
-It is a common practice to prefix app's environment variables with some string
-(e.g., its name). Such a prefix can be set using the `WithPrefix` option:
-
-```go
-os.Setenv("APP_PORT", "8080")
-
-var cfg struct {
-    Port int `env:"PORT"`
-}
-if err := env.Load(&cfg, env.WithPrefix("APP_")); err != nil {
     fmt.Println(err)
 }
 

--- a/env.go
+++ b/env.go
@@ -57,12 +57,6 @@ func WithSource(src Source) Option {
 	return func(l *loader) { l.source = src }
 }
 
-// WithPrefix configures [Load] to automatically add the provided prefix to each environment variable.
-// By default, no prefix is configured.
-func WithPrefix(prefix string) Option {
-	return func(l *loader) { l.prefix = prefix }
-}
-
 // WithSliceSeparator configures [Load] to use the provided separator when parsing slice values.
 // The default separator is space.
 func WithSliceSeparator(sep string) Option {
@@ -82,14 +76,12 @@ func (e *NotSetError) Error() string {
 
 type loader struct {
 	source   Source
-	prefix   string
 	sliceSep string
 }
 
 func newLoader(opts []Option) *loader {
 	l := loader{
 		source:   OS,
-		prefix:   "",
 		sliceSep: " ",
 	}
 	for _, opt := range opts {
@@ -189,7 +181,7 @@ func (l *loader) parseVars(v reflect.Value) []Var {
 		}
 
 		vars = append(vars, Var{
-			Name:          l.prefix + name,
+			Name:          name,
 			Type:          field.Type(),
 			Desc:          sf.Tag.Get("desc"),
 			Default:       defValue,

--- a/example_test.go
+++ b/example_test.go
@@ -99,20 +99,6 @@ func ExampleWithSource() {
 	// Output: 8080
 }
 
-func ExampleWithPrefix() {
-	os.Setenv("APP_PORT", "8080")
-
-	var cfg struct {
-		Port int `env:"PORT"`
-	}
-	if err := env.Load(&cfg, env.WithPrefix("APP_")); err != nil {
-		fmt.Println(err)
-	}
-
-	fmt.Println(cfg.Port)
-	// Output: 8080
-}
-
 func ExampleWithSliceSeparator() {
 	os.Setenv("PORTS", "8080;8081;8082")
 

--- a/usage.go
+++ b/usage.go
@@ -9,7 +9,7 @@ import (
 
 // Var contains the information about the environment variable parsed from a struct field.
 type Var struct {
-	Name     string       // The full name of the variable, including the prefix.
+	Name     string       // The full name of the variable.
 	Type     reflect.Type // The type of the variable.
 	Desc     string       // The description parsed from the `desc` tag (if exists).
 	Default  string       // The default value of the variable. Empty, if the variable is required.


### PR DESCRIPTION
Full variable name in the `env` tag is more readable.